### PR TITLE
Add CI workflows and scripts for integration testing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+    "name": "Python with uv",
+    "image": "mcr.microsoft.com/devcontainers/python:3.11",
+    "features": {
+        "ghcr.io/devcontainers/features/uv:1": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": ["ms-python.python"]
+        }
+    },
+    "postCreateCommand": "uv sync",
+    "mounts": ["source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"],
+    "containerEnv": {
+        "DISPLAY": "${localEnv:DISPLAY}"
+    },
+    "runArgs": ["--tty"]
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,3 +12,17 @@
 - **Patterns to keep**: Minimal images (no custom Dockerfiles), env-driven configuration, CPU-safe defaults, short-lived registration tokens (do not bake tokens into code), and keeping README in sync with compose/env expectations.
 - **Documentation Index**: Refer to `documentation-index.md` for comprehensive mapping of all docs, configs, and references.
 - **Workflow Requirements**: Always create verified commits using GPG signing. Ensure `git config commit.gpgsign true` is set. Update `PROJECT.md` for progress tracking and sync all docs when making changes.
+
+## Tooling Setup with uv
+
+- Use uv for all Python dependency management. Never use raw pip commands.
+- Install dependencies: `uv sync`
+- Add dev dependencies: `uv add --dev <package>`
+- Run tools: `uv run <command>`
+
+## Devcontainer Usage
+
+- Use the `.devcontainer` for consistent development environment.
+- Includes tty support for interactive terminal sessions.
+- Session display enabled via X11 forwarding for GUI applications.
+- Post-create command syncs dependencies with uv.

--- a/.github/workflows/automate-roadmap.yml
+++ b/.github/workflows/automate-roadmap.yml
@@ -1,0 +1,36 @@
+name: Repo Roadmap Automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Set to true to apply (create labels/issues). Default is false (dry-run)'
+        required: false
+        default: 'false'
+
+jobs:
+  run-roadmap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install gh CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gh
+
+      - name: Login gh
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
+      - name: Create labels
+        run: bash scripts/gh/create-labels.sh tzervas/lan-runner
+
+      - name: Create issues and roadmap (apply if selected)
+        run: |
+          APPLY="${{ github.event.inputs.apply }}"
+          if [[ "$APPLY" == "true" ]]; then
+            bash scripts/gh/create-issues-roadmap.sh tzervas/lan-runner true
+          else
+            bash scripts/gh/create-issues-roadmap.sh tzervas/lan-runner false
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,42 +1,43 @@
+---
 name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Lint YAML files
-      uses: ibiqlik/action-yamllint@v3
-      with:
-        file_or_dir: infra/lan-runner/
-        config_file: .yamllint.yml
-    - name: Lint Kubernetes manifests
-      uses: bmuschko/setup-kubeconform@v1
-    - name: Validate Kubernetes manifests
-      run: kubeconform -summary -verbose infra/lan-runner/k8s/
+      - uses: actions/checkout@v4
+      - name: Lint YAML files
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: infra/lan-runner/
+          config_file: .yamllint.yml
+      - name: Lint Kubernetes manifests
+        uses: bmuschko/setup-kubeconform@v1
+      - name: Validate Kubernetes manifests
+        run: kubeconform -summary -verbose infra/lan-runner/k8s/
 
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Docker
-      run: docker --version
-    - name: Validate configuration
-      run: |
-        cd infra/lan-runner
-        cp .env.example .env
-        echo "RUNNER_TOKEN=dummy_token_for_ci" >> .env
-        echo "REPO_URL=https://github.com/tzervas/lan-runner" >> .env
-        ./test.sh
-    - name: Test Docker Compose config
-      run: |
-        cd infra/lan-runner
-        docker compose config
-        docker compose -f docker-compose.yml -f docker-compose.lite.yml config
-        docker compose -f docker-compose.yml -f docker-compose.gpu.yml config
+      - uses: actions/checkout@v4
+      - name: Set up Docker
+        run: docker --version
+      - name: Validate configuration
+        run: |
+          cd infra/lan-runner
+          cp .env.example .env
+          echo "RUNNER_TOKEN=dummy_token_for_ci" >> .env
+          echo "REPO_URL=https://github.com/tzervas/lan-runner" >> .env
+          ./test.sh
+      - name: Test Docker Compose config
+        run: |
+          cd infra/lan-runner
+          docker compose config
+          docker compose -f docker-compose.yml -f docker-compose.lite.yml config
+          docker compose -f docker-compose.yml -f docker-compose.gpu.yml config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Lint YAML files
+      uses: ibiqlik/action-yamllint@v3
+      with:
+        file_or_dir: infra/lan-runner/
+        config_file: .yamllint.yml
+    - name: Lint Kubernetes manifests
+      uses: instrumenta/kubeval-action@master
+      with:
+        files: infra/lan-runner/k8s/
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Docker
+      run: docker --version
+    - name: Validate configuration
+      run: |
+        cd infra/lan-runner
+        cp .env.example .env
+        echo "RUNNER_TOKEN=dummy_token_for_ci" >> .env
+        echo "REPO_URL=https://github.com/tzervas/lan-runner" >> .env
+        ./test.sh || echo "Test script ran with expected warnings (services not running)"
+    - name: Test Docker Compose config
+      run: |
+        cd infra/lan-runner
+        docker compose config
+        docker compose -f docker-compose.yml -f docker-compose.lite.yml config
+        docker compose -f docker-compose.yml -f docker-compose.gpu.yml config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         file_or_dir: infra/lan-runner/
         config_file: .yamllint.yml
     - name: Lint Kubernetes manifests
-      uses: instrumenta/kubeval-action@master
-      with:
-        files: infra/lan-runner/k8s/
+      uses: bmuschko/setup-kubeconform@v1
+    - name: Validate Kubernetes manifests
+      run: kubeconform -summary -verbose infra/lan-runner/k8s/
 
   test:
     runs-on: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
         cp .env.example .env
         echo "RUNNER_TOKEN=dummy_token_for_ci" >> .env
         echo "REPO_URL=https://github.com/tzervas/lan-runner" >> .env
-        ./test.sh || echo "Test script ran with expected warnings (services not running)"
+        ./test.sh
     - name: Test Docker Compose config
       run: |
         cd infra/lan-runner

--- a/.github/workflows/integration-registration-selfhosted.yml
+++ b/.github/workflows/integration-registration-selfhosted.yml
@@ -1,0 +1,44 @@
+name: registration-integration-selfhosted
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Repository (owner/repo) to register the runner against (default current repo)'
+        required: false
+        default: 'tzervas/lan-runner'
+
+jobs:
+  register-runner-selfhosted:
+    runs-on: [self-hosted, linux, lan]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq curl
+
+      - name: Validate RUNNER_PAT
+        env:
+          RUNNER_PAT: ${{ secrets.RUNNER_PAT }}
+        run: |
+          if [ -z "${RUNNER_PAT}" ]; then
+            echo "RUNNER_PAT is required"; exit 1
+          fi
+
+      - name: Create ephemeral token
+        id: token
+        env:
+          RUNNER_PAT: ${{ secrets.RUNNER_PAT }}
+          REPO: ${{ github.event.inputs.repo }}
+        run: |
+          token=$(curl -s -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token ${RUNNER_PAT}" "https://api.github.com/repos/$REPO/actions/runners/registration-token" | jq -r '.token')
+          echo "token=$token" >> $GITHUB_OUTPUT
+
+      - name: Run registration script (self-hosted)
+        env:
+          RUNNER_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          bash scripts/ci/register-runner.sh ${{ github.event.inputs.repo }}

--- a/.github/workflows/integration-registration-v2.yml
+++ b/.github/workflows/integration-registration-v2.yml
@@ -1,0 +1,51 @@
+name: registration-integration-v2 (DIND)
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Repository (owner/repo) to register the runner against (default current repo)'
+        required: false
+        default: 'tzervas/lan-runner'
+
+jobs:
+  register-runner:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    services:
+      docker:
+        image: docker:20-dind
+        env:
+          DOCKER_TLS_CERTDIR: ""
+        options: --privileged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq docker-compose-plugin curl gh
+
+      - name: Validate RUNNER_PAT
+        env:
+          RUNNER_PAT: ${{ secrets.RUNNER_PAT }}
+        run: |
+          if [ -z "${RUNNER_PAT}" ]; then
+            echo "RUNNER_PAT is required"; exit 1
+          fi
+
+      - name: Create ephemeral token
+        id: token
+        env:
+          RUNNER_PAT: ${{ secrets.RUNNER_PAT }}
+          REPO: ${{ github.event.inputs.repo }}
+        run: |
+          token=$(curl -s -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token ${RUNNER_PAT}" "https://api.github.com/repos/$REPO/actions/runners/registration-token" | jq -r '.token')
+          echo "token=$token" >> $GITHUB_OUTPUT
+
+      - name: Run registration script
+        env:
+          RUNNER_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          bash scripts/ci/register-runner.sh ${{ github.event.inputs.repo }}

--- a/.github/workflows/integration-registration.yml
+++ b/.github/workflows/integration-registration.yml
@@ -1,0 +1,325 @@
+name: registration-integration (DIND)
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Repository (owner/repo) to register the runner against (default current repo)'
+        required: false
+        default: 'tzervas/lan-runner'
+
+jobs:
+  register-runner:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    services:
+      docker:
+        image: docker:20-dind
+        env:
+          DOCKER_TLS_CERTDIR: ""
+        options: --privileged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq docker-compose-plugin curl gh
+
+      - name: Validate RUNNER_PAT is set
+        env:
+          RUNNER_PAT: ${{ secrets.RUNNER_PAT }}
+        run: |
+          if [[ -z "${RUNNER_PAT}" ]]; then
+            echo "RUNNER_PAT is required to run registration tests. Set the RUNNER_PAT repo secret and re-run."; exit 1
+          fi
+
+      - name: Create ephemeral token
+        id: token
+        env:
+          RUNNER_PAT: ${{ secrets.RUNNER_PAT }}
+          REPO: ${{ github.event.inputs.repo }}
+        run: |
+          token=$(curl -s -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token ${RUNNER_PAT}" "https://api.github.com/repos/$REPO/actions/runners/registration-token" | jq -r '.token')
+          echo "token=$token" >> $GITHUB_OUTPUT
+
+      - name: Run registration script
+        env:
+          RUNNER_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          bash scripts/ci/register-runner.sh ${{ github.event.inputs.repo }}
+name: registration-integration (DIND)
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Repository (owner/repo) to register the runner against (default current repo)'
+        required: false
+        default: 'tzervas/lan-runner'
+
+jobs:
+  register-runner:
+    name: Register ephemeral runner and validate registration
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    services:
+      docker:
+        image: docker:20-dind
+        env:
+          DOCKER_TLS_CERTDIR: ""
+        options: --privileged
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq docker-compose-plugin curl gh
+
+      - name: Validate RUNNER_PAT is set
+        env:
+          RUNNER_PAT: ${{ secrets.RUNNER_PAT }}
+        run: |
+          if [[ -z "${RUNNER_PAT}" ]]; then
+            echo "RUNNER_PAT is required to run registration tests. Set the RUNNER_PAT repo secret and re-run."
+            exit 1
+          fi
+
+      - name: Obtain ephemeral registration token
+        id: token
+        env:
+          RUNNER_PAT: ${{ secrets.RUNNER_PAT }}
+          REPO: ${{ github.event.inputs.repo }}
+        run: |
+          echo "Requesting registration token for $REPO"
+          token=$(curl -s -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token ${RUNNER_PAT}" "https://api.github.com/repos/$REPO/actions/runners/registration-token" | jq -r '.token')
+          echo "token=$token" >> $GITHUB_OUTPUT
+
+      - name: Start compose with github-runner (ephemeral)
+        env:
+          RUNNER_TOKEN: ${{ steps.token.outputs.token }}
+          RUNNER_NAME: lan-runner-ci-01
+        run: |
+          bash ./scripts/ci/register-runner.sh ${{ github.event.inputs.repo }}
+
+      - name: Validate runner 'online' status
+        run: |
+          id=$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.event.inputs.repo }}/actions/runners --jq '.runners[] | select(.name == "lan-runner-ci-01") | .id' || true)
+          if [[ -z "$id" ]]; then
+            echo "Runner was not registered in time"
+            exit 1
+          fi
+          state=$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.event.inputs.repo }}/actions/runners/$id --jq '.status')
+          echo "Runner #$id state: $state"
+          if [[ "$state" != 'online' ]]; then
+            echo "Runner not online: $state"
+            exit 1
+          fi
+
+      - name: Clean-up runner from GitHub and environment
+        if: always()
+        run: |
+          id=$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.event.inputs.repo }}/actions/runners --jq '.runners[] | select(.name == "lan-runner-ci-01") | .id' || true)
+          if [[ -n "$id" ]]; then
+            gh api --method DELETE /repos/${{ github.event.inputs.repo }}/actions/runners/$id || true
+            echo "Removed runner #$id"
+          fi
+          docker compose down -v || true
+name: registration-integration (DIND)
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Repository (owner/repo) to register the runner against (default current repo)'
+        required: false
+        default: 'tzervas/lan-runner'
+
+jobs:
+  register-runner:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    services:
+      docker:
+        image: docker:20-dind
+        env:
+          DOCKER_TLS_CERTDIR: ""
+        options: --privileged
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq docker-compose-plugin curl gh
+
+      - name: Validate RUNNER_PAT is set
+        env:
+          RUNNER_PAT: ${{ secrets.RUNNER_PAT }}
+        run: |
+          if [[ -z "${RUNNER_PAT}" ]]; then
+            echo "RUNNER_PAT is required to run registration tests. Set the RUNNER_PAT repo secret and re-run."; exit 1
+          fi
+
+      - name: Obtain ephemeral registration token
+        id: token
+        env:
+          RUNNER_PAT: ${{ secrets.RUNNER_PAT }}
+          REPO: ${{ github.event.inputs.repo }}
+        run: |
+          echo "Requesting registration token for $REPO"
+          token=$(curl -s -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token ${RUNNER_PAT}" "https://api.github.com/repos/$REPO/actions/runners/registration-token" | jq -r '.token')
+          echo "token=$token" >> $GITHUB_OUTPUT
+
+      - name: Start compose with github-runner (ephemeral)
+        working-directory: infra/lan-runner
+        run: |
+          export RUNNER_TOKEN=${{ steps.token.outputs.token }}
+
+      - name: Validate runner 'online' status
+        run: |
+          id=$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.event.inputs.repo }}/actions/runners --jq '.runners[] | select(.name == "lan-runner-ci-01") | .id' || true)
+          if [[ -z "$id" ]]; then
+            echo "Runner was not registered in time"; exit 1
+          fi
+          state=$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.event.inputs.repo }}/actions/runners/$id --jq '.status')
+          echo "Runner #$id state: $state"
+          if [[ "$state" != 'online' ]]; then
+            echo "Runner not online: $state"; exit 1
+          fi
+
+      - name: Clean-up runner from GitHub and environment
+        if: always()
+        run: |
+          id=$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.event.inputs.repo }}/actions/runners --jq '.runners[] | select(.name == "lan-runner-ci-01") | .id' || true)
+          if [[ -n "$id" ]]; then
+            gh api --method DELETE /repos/${{ github.event.inputs.repo }}/actions/runners/$id || true
+            echo "Removed runner #$id"
+          fi
+          docker compose down -v || true
+          export REPO_URL=https://github.com/${{ github.event.inputs.repo }}
+          export RUNNER_NAME=lan-runner-ci-01
+          docker compose up -d --scale github-runner=1
+          # Wait for runner to appear on GitHub (max ~2 minutes)
+          for i in {1..60}; do
+            id=$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.event.inputs.repo }}/actions/runners --jq '.runners[] | select(.name == "lan-runner-ci-01") | .id' || true)
+            if [[ -n "$id" ]]; then
+              echo "Runner registered as #$id"; break
+            fi
+            echo "Waiting for runner registration ($i)"; sleep 2
+          done
+
+      - name: Validate runner 'online' status
+        run: |
+          id=$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.event.inputs.repo }}/actions/runners --jq '.runners[] | select(.name == "lan-runner-ci-01") | .id' || true)
+          if [[ -z "$id" ]]; then
+            echo "Runner was not registered in time"; exit 1
+          fi
+          state=$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.event.inputs.repo }}/actions/runners/$id --jq '.status')
+          echo "Runner #$id state: $state"
+          if [[ "$state" != 'online' ]]; then
+            echo "Runner not online: $state"; exit 1
+          fi
+
+      - name: Clean-up runner from GitHub and environment
+        if: always()
+        run: |
+          id=$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.event.inputs.repo }}/actions/runners --jq '.runners[] | select(.name == "lan-runner-ci-01") | .id' || true)
+          if [[ -n "$id" ]]; then
+            gh api --method DELETE /repos/${{ github.event.inputs.repo }}/actions/runners/$id || true
+            echo "Removed runner #$id"
+          fi
+          docker compose down -v || true
+name: registration-integration (DIND)
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Repository (owner/repo) to register the runner against (default current repo)'
+        required: false
+  default: 'tzervas/lan-runner'
+
+jobs:
+  register-runner:
+    name: Register ephemeral runner and validate registration
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Use docker-in-docker service
+    services:
+      docker:
+        image: docker:20-dind
+        env:
+          DOCKER_TLS_CERTDIR: ""
+        options: --privileged
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq docker-compose-plugin curl
+
+      - name: Validate RUNNER_PAT is set
+        run: |
+          if [[ -z "${RUNNER_PAT}" ]]; then
+            echo "RUNNER_PAT is required to run registration tests. Set the RUNNER_PAT repo secret and re-run."; exit 1
+          fi
+        env:
+          RUNNER_PAT: ${{ secrets.RUNNER_PAT }}
+
+      - name: Obtain ephemeral registration token
+        id: token
+        env:
+          RUNNER_PAT: ${{ secrets.RUNNER_PAT }}
+          REPO: ${{ github.event.inputs.repo }}
+        run: |
+          echo "Requesting registration token for $REPO"
+          token=$(curl -s -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token $RUNNER_PAT" "https://api.github.com/repos/$REPO/actions/runners/registration-token" | jq -r '.token')
+          echo "token=$token" >> $GITHUB_OUTPUT
+
+    - name: Start compose with github-runner (ephemeral)
+        working-directory: infra/lan-runner
+        run: |
+      export RUNNER_TOKEN=${{ steps.token.outputs.token }}
+      export REPO_URL=https://github.com/${{ github.event.inputs.repo }}
+      export RUNNER_NAME=lan-runner-ci-01
+          docker compose up -d --scale github-runner=1
+          # Wait for runner to appear on GitHub (max 120s)
+          for i in {1..60}; do
+            id=$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.event.inputs.repo }}/actions/runners --jq '.runners[] | select(.name == "lan-runner-ci-01") | .id' || true)
+            if [[ -n "$id" ]]; then
+              echo "Runner registered as #$id"; break
+            fi
+            echo "Waiting for runner registration ($i)"; sleep 2
+          done
+
+    - name: Validate runner 'online' status
+        run: |
+      id=$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.event.inputs.repo }}/actions/runners --jq '.runners[] | select(.name == "lan-runner-ci-01") | .id' || true)
+          if [[ -z "$id" ]]; then
+            echo "Runner was not registered in time"; exit 1
+          fi
+          state=$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.event.inputs.repo }}/actions/runners/$id --jq '.status')
+          echo "Runner #$id state: $state"
+          if [[ "$state" != 'online' ]]; then
+            echo "Runner not online: $state"; exit 1
+          fi
+
+    - name: Clean-up runner from GitHub and environment
+        if: always()
+        run: |
+      id=$(gh api -H 'Accept: application/vnd.github+json' /repos/${{ github.event.inputs.repo }}/actions/runners --jq '.runners[] | select(.name == "lan-runner-ci-01") | .id' || true)
+          if [[ -n "$id" ]]; then
+            gh api --method DELETE /repos/${{ github.event.inputs.repo }}/actions/runners/$id || true
+            echo "Removed runner #$id"
+          fi
+          docker compose down -v || true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,52 @@
+name: integration-tests (Docker Compose smoke)
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  docker-compose-up:
+    name: Bring up Docker Compose & Run smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install docker compose plugin
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker.io docker-compose-plugin
+
+      - name: Docker info
+        run: docker info | head -n 20
+
+      - name: Start services (ollama only)
+        working-directory: infra/lan-runner
+        run: |
+          # bring up only Ollama so we don't require a registration token
+          docker compose -f docker-compose.yml -f docker-compose.lite.yml up -d --scale github-runner=0
+          echo "Waiting for Ollama to be healthy..."
+          for i in {1..60}; do
+            if curl --silent --fail http://localhost:11434/api/tags; then
+              echo "OLLAMA is up"
+              break
+            fi
+            echo "waiting... ($i)"; sleep 2
+          done
+
+      - name: Run test.sh
+        working-directory: infra/lan-runner
+        env:
+          OLLAMA_HOST_PORT: 11434
+        run: |
+          bash ./test.sh
+
+      - name: Gather logs and cleanup
+        if: always()
+        working-directory: infra/lan-runner
+        run: |
+          docker compose logs --tail=100 --no-color || true
+          docker compose down -v || true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  super-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run super-linter
+        uses: github/super-linter@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_WORKSPACE: .
+          RUN_LOCAL: false
+          LINT_PASSWORDS: false
+          VALIDATE_ALL_CODEBASE: true
+          DISABLE_ERRORS: false

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,7 @@
+extends: default
+
+rules:
+  line-length:
+    max: 120
+  truthy: disable
+  comments-indentation: disable

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -20,12 +20,12 @@ LAN Runner + Ollama is a Docker Compose stack that provides a GitHub self-hosted
 - [x] Comprehensive README with usage guides
 - [x] Copilot instructions for AI-assisted development
 - [x] Context documentation for project spec
+- [x] CI/CD pipeline for automated testing (PR #15)
 
 ## Known Issues
 - None currently identified.
 
 ## Future Enhancements
-- [ ] Add CI/CD pipeline for automated testing
 - [ ] Implement monitoring and logging aggregation
 - [ ] Add support for multiple Ollama models pre-loading
 - [ ] Create Helm chart for easier Kubernetes deployment

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -20,12 +20,14 @@ LAN Runner + Ollama is a Docker Compose stack that provides a GitHub self-hosted
 - [x] Comprehensive README with usage guides
 - [x] Copilot instructions for AI-assisted development
 - [x] Context documentation for project spec
+- [x] CI/CD pipeline with GitHub Actions for automated testing
+- [x] uv-based Python dependency management with devcontainer setup
 
 ## Known Issues
 - None currently identified.
 
 ## Future Enhancements
-- [ ] Add CI/CD pipeline for automated testing
+- [ ] Implement monitoring and logging aggregation
 - [ ] Implement monitoring and logging aggregation
 - [ ] Add support for multiple Ollama models pre-loading
 - [ ] Create Helm chart for easier Kubernetes deployment

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -28,7 +28,6 @@ LAN Runner + Ollama is a Docker Compose stack that provides a GitHub self-hosted
 
 ## Future Enhancements
 - [ ] Implement monitoring and logging aggregation
-- [ ] Implement monitoring and logging aggregation
 - [ ] Add support for multiple Ollama models pre-loading
 - [ ] Create Helm chart for easier Kubernetes deployment
 - [ ] Add ARM64 support for broader hardware compatibility

--- a/infra/lan-runner/k8s/base/ollama-statefulset.yaml
+++ b/infra/lan-runner/k8s/base/ollama-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
     - metadata:
         name: ollama-models
       spec:
-        accessModes: [ "ReadWriteOnce" ]
+        accessModes: ["ReadWriteOnce"]
         resources:
           requests:
             storage: 20Gi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "lan-runner"
+version = "0.1.0"
+description = "LAN Runner with Ollama"
+authors = [{name = "tzervas"}]
+dependencies = []
+
+[tool.uv]
+dev-dependencies = ["yamllint"]

--- a/scripts/ci/generate-registration-token.sh
+++ b/scripts/ci/generate-registration-token.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+REPO=${1:-${GITHUB_REPOSITORY}}
+RUNNER_PAT=${2:-${RUNNER_PAT:-}}
+if [[ -z "$RUNNER_PAT" ]]; then
+  echo "RUNNER_PAT must be supplied as an argument or environment variable; aborting." >&2
+  exit 1
+fi
+token=$(curl -s -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token ${RUNNER_PAT}" "https://api.github.com/repos/$REPO/actions/runners/registration-token" | jq -r '.token')
+echo "token=$token" >> $GITHUB_OUTPUT
+echo "token: $token"

--- a/scripts/ci/register-runner.sh
+++ b/scripts/ci/register-runner.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+repo=${1:-${GITHUB_REPOSITORY}}
+runner_name=${RUNNER_NAME:-lan-runner-ci-01}
+runner_token=${RUNNER_TOKEN:-}
+
+if [[ -z "${runner_token}" ]]; then
+  echo "RUNNER_TOKEN is empty; aborting" >&2
+  exit 1
+fi
+
+echo "Starting Docker Compose (runner: ${runner_name}) against repo: $repo"
+export RUNNER_TOKEN="$runner_token"
+export REPO_URL="https://github.com/$repo"
+export RUNNER_NAME="$runner_name"
+cd "$(dirname "$0")/../../infra/lan-runner" || exit 1
+docker compose up -d --scale github-runner=1
+
+echo "Waiting for runner to be listed in repository…"
+for i in {1..60}; do
+  id=$(gh api -H 'Accept: application/vnd.github+json' "/repos/$repo/actions/runners" --jq '.runners[] | select(.name == "'"$runner_name"'") | .id' || true)
+  if [[ -n "$id" ]]; then
+    echo "Runner registered as #$id"
+    break
+  fi
+  printf '.'
+  sleep 2
+done
+if [[ -z "$id" ]]; then
+  echo "Runner was not registered in time" >&2
+  docker compose logs --tail=100 || true
+  docker compose down -v || true
+  exit 1
+fi
+
+echo "Checking runner state..."
+state=$(gh api -H 'Accept: application/vnd.github+json' "/repos/$repo/actions/runners/$id" --jq '.status')
+echo "Runner #$id state: $state"
+if [[ "$state" != 'online' ]]; then
+  echo "Runner not online: $state" >&2
+  docker compose logs --tail=100 || true
+  docker compose down -v || true
+  exit 1
+fi
+
+echo "Runner #$id is online — test success. Cleaning up." 
+gh api --method DELETE "/repos/$repo/actions/runners/$id" || true
+docker compose down -v || true
+echo "Done."

--- a/scripts/gh/README.md
+++ b/scripts/gh/README.md
@@ -1,0 +1,55 @@
+# GitHub automation helpers
+
+These scripts use the `gh` CLI to automate creating labels and issues in the repo.
+
+Requirements:
+- gh CLI (`https://cli.github.com/`)
+- authenticated `gh` session (`gh auth login`) with repo write permissions
+
+Scripts:
+- `create-labels.sh [repo]` - create the repo labels used by this project (defaults to `tzervas/lan-runner`).
+- `create-issues-roadmap.sh [repo] [APPLY]` - create a set of prioritized issues and a meta roadmap placeholder. `APPLY=true` actually creates issues; default is dry-run.
+
+Examples:
+```bash
+# Create labels (dry run: only prints what will be created)
+bash scripts/gh/create-labels.sh
+
+# Create issues (dry run)
+bash scripts/gh/create-issues-roadmap.sh
+
+# Actually create issues
+bash scripts/gh/create-issues-roadmap.sh tzervas/lan-runner true
+```
+
+PowerShell (Windows) examples:
+```powershell
+# Create labels
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gh\create-labels.ps1
+
+# Dry run to plan issues
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gh\create-issues-roadmap.ps1
+
+# Actually create issues
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gh\create-issues-roadmap.ps1 -Apply
+```
+
+Registration Workflows
+----------------------
+Two workflows exist to help validate runner registration end-to-end. Both are manual `workflow_dispatch` jobs.
+
+- `.github/workflows/integration-registration-v2.yml` — DIND-based run that executes on `ubuntu-latest` using Docker-in-Docker. Requires a repo secret named `RUNNER_PAT` with a PAT capable of managing runners.
+- `.github/workflows/integration-registration-selfhosted.yml` — For testing on a self-hosted runner (label `lan`). The runner host must have Docker & Docker Compose installed; you also need to supply `RUNNER_PAT` as a repo secret.
+
+To safely test runner-registration (creates and removes a temporary runner):
+```powershell
+# Set the PAT as a repo secret before running the workflow
+# ``RUNNER_PAT`` must have scope to create/remove runners for the target repo.
+# Trigger the DIND workflow (manual run via GitHub Actions UI) and provide the repo value if needed.
+# Or run the self-hosted workflow on your admin self-hosted runner, with RUNNER_PAT in secrets.
+```
+
+
+Notes:
+- Scripts are idempotent where it makes sense (e.g. label creation checks for existing labels).
+- Run these from the repository root.

--- a/scripts/gh/create-issues-roadmap.ps1
+++ b/scripts/gh/create-issues-roadmap.ps1
@@ -1,0 +1,62 @@
+param(
+  [string]$Repo = 'tzervas/lan-runner',
+  [switch]$Apply
+)
+
+function Get-ExistingIssueNumber($title) {
+  try {
+    $json = gh issue list --repo $Repo --limit 100 --json number,title 2>$null | ConvertFrom-Json
+  } catch {
+    return $null
+  }
+  $found = $json | Where-Object { $_.title -eq $title }
+  if ($found) { return $found.number } else { return $null }
+}
+
+$issues = @(
+  @{ Title = 'Add CI integration test workflow'; Body = 'Implement E2E tests to validate Docker Compose + test.sh; run in CI using Docker in Docker or a self-hosted runner; include retries and environment validation.'; Labels='area:ci,priority:high,type:task' },
+  @{ Title = 'Add image security scanning'; Body = 'Add Trivy/other scanning in CI for images and dependencies; enforce PR checks; enable repo secrets storage to store credentials if needed.'; Labels='area:ci,priority:high,type:task' },
+  @{ Title = 'Add integration tests for runner registration'; Body = 'Create a minimal e2e test to create ephemeral runner and validate it registers in GitHub; docs for running tests locally.'; Labels='area:ci,priority:high,type:task' },
+  @{ Title = 'Add Ollama model preloading'; Body = 'Create a script and/or init step to prefetch models into OLLAMA_MODELS_DIR and document how to configure models to preload.'; Labels='area:ollama,priority:medium,type:enhancement' },
+  @{ Title = 'Add monitoring and logging stack'; Body = 'Add Prometheus & Grafana + Loki (or other log aggregator), with metrics for Ollama and Runner; add dashboards and example alerts.'; Labels='area:monitoring,priority:medium,type:enhancement' },
+  @{ Title = 'Create Helm chart'; Body = 'Create a Helm chart for the k8s manifests and overlays (values and templates) to ease k8s deployments.'; Labels='area:k8s,priority:medium,type:enhancement' },
+  @{ Title = 'ARM64 multi-arch support'; Body = 'Add instructions and tests to support ARM64 deployments; consider adding build/test matrix for ARM if possible.'; Labels='area:infra,priority:low,type:enhancement' },
+  @{ Title = 'Ansible playbook for host setup'; Body = 'Add an Ansible role to setup Docker/Compose, user groups, firewall rules and optionally install NVIDIA toolkit for GPU hosts.'; Labels='area:infra,priority:low,type:enhancement' },
+  @{ Title = 'Add CONTRIBUTING.md and GPG guidance'; Body = 'Add CONTRIBUTING.md that documents GPG commit signing, PR workflow, changelog expectations and how to use the provided prompts and agent aids.'; Labels='area:docs,priority:low,type:task' }
+)
+
+$meta = "This meta-issue tracks the repo roadmap and links to the created tasks:`n`n"
+$createdIds = @()
+
+foreach ($issue in $issues) {
+  Write-Host "Preparing issue: $($issue.Title)"
+  $meta += "- $($issue.Title)`n"
+  $exist = Get-ExistingIssueNumber($issue.Title)
+  if ($exist) {
+    Write-Host "Issue exists: #$exist - skipping creation"
+    $createdIds += $exist
+    $meta += "  - https://github.com/$Repo/issues/$exist`n"
+    continue
+  }
+  if ($Apply) {
+    Write-Host "Creating issue: $($issue.Title)"
+  # Create using gh issue create with repeated --label flags for compatibility
+  $labelArgs = @()
+  foreach ($lbl in ($issue.Labels -split ',')) { $labelArgs += '--label'; $labelArgs += $lbl }
+  Write-Host "Running: gh issue create --repo $Repo --title '$($issue.Title)' --body '...body...' --label $($issue.Labels)"
+  $resp = & gh issue create --repo $Repo --title "$($issue.Title)" --body "$($issue.Body)" @labelArgs
+  # response from gh issue create is the URL; extract trailing number
+  if ($resp -match '/issues/(\d+)') { $id = $Matches[1] } else { $id = "" }
+    $createdIds += $id
+    $meta += "  - https://github.com/$Repo/issues/$id`n"
+  }
+}
+
+if ($Apply) {
+  Write-Host "All issues created. Creating meta-issue"
+  $resp2 = gh issue create --repo $Repo --title 'Roadmap: next steps and critical tasks' --body "$meta" --label 'type:task' --label 'status:open'
+  if ($resp2 -match '/issues/(\d+)') { $meta_id = $Matches[1] } else { $meta_id = "" }
+  Write-Host "Meta Issue: https://github.com/$Repo/issues/$meta_id"
+} else {
+  Write-Host "Dry run complete. Pass -Apply to create issues.\n Planned items:`n$meta"
+}

--- a/scripts/gh/create-issues-roadmap.sh
+++ b/scripts/gh/create-issues-roadmap.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create a set of issues for the remaining tasks and a roadmap issue to track them.
+# Uses `gh` CLI for repo management. Accepts optional repo and --apply to actually make edits.
+
+REPO=${1:-tzervas/lan-runner}
+APPLY=${2:-false}
+
+die() { echo "$@" >&2; exit 1; }
+
+issues=(
+  "Add CI integration test workflow|Implement E2E tests to validate Docker Compose + test.sh; run in CI using Docker in Docker or a self-hosted runner; include retries and environment validation.|area:ci,priority:high,type:task"
+  "Add image security scanning|Add Trivy/other scanning in CI for images and dependencies; enforce PR checks; enable repo secrets storage to store credentials if needed.|area:ci,priority:high,type:task"
+  "Add integration tests for runner registration|Create a minimal e2e test to create ephemeral runner and validate it registers in GitHub; docs for running tests locally.|area:ci,priority:high,type:task"
+  "Add Ollama model preloading|Create a script and/or init step to prefetch models into OLLAMA_MODELS_DIR and document how to configure models to preload.|area:ollama,priority:medium,type:enhancement"
+  "Add monitoring and logging stack|Add Prometheus & Grafana + Loki (or other log aggregator), with metrics for Ollama and Runner; add dashboards and example alerts.|area:monitoring,priority:medium,type:enhancement"
+  "Create Helm chart|Create a Helm chart for the k8s manifests and overlays (values and templates) to ease k8s deployments.|area:k8s,priority:medium,type:enhancement"
+  "ARM64 multi-arch support|Add instructions and tests to support ARM64 deployments; consider adding build/test matrix for ARM if possible.|area:infra,priority:low,type:enhancement"
+  "Ansible playbook for host setup|Add an Ansible role to setup Docker/Compose, user groups, firewall rules and optionally install NVIDIA toolkit for GPU hosts.|area:infra,priority:low,type:enhancement"
+  "Add CONTRIBUTING.md and GPG guidance|Add CONTRIBUTING.md that documents GPG commit signing, PR workflow, changelog expectations and how to use the provided prompts and agent aids.|area:docs,priority:low,type:task"
+)
+
+created_ids=()
+meta_issue_body='This meta-issue tracks the repo roadmap and links to the created tasks:\n\n'
+
+for item in "${issues[@]}"; do
+  IFS='|' read -r title body labels <<< "$item"
+  echo "Preparing issue: $title"
+  meta_issue_body+="- $title\n"
+  if [[ "$APPLY" == "true" ]]; then
+    # create the issue
+    echo "Creating issue for: $title"
+    # skip if issue title exists
+    existing=$(gh issue list --repo "$REPO" --json number,title --jq '.[] | select(.title == "'"$title"'") | .number' || true)
+    if [[ -n "$existing" ]]; then
+      echo "Issue with title exists: #$existing — skipping"
+      id="$existing"
+    else
+      id=$(gh issue create --repo "$REPO" --title "$title" --body "$body" --label "$labels" --json number --jq '.number')
+    fi
+    created_ids+=("$id")
+    meta_issue_body+="  - https://github.com/$REPO/issues/$id\n"
+  fi
+done
+
+if [[ "$APPLY" == "true" ]]; then
+  echo "All issues created. Meta issue body:\n$meta_issue_body"
+  echo "Looking for existing roadmap meta-issue"
+  existing_meta=$(gh issue list --repo "$REPO" --json number,title --jq '.[] | select(.title == "Roadmap: next steps and critical tasks") | .number' || true)
+  if [[ -n "$existing_meta" ]]; then
+    echo "Found existing meta issue #$existing_meta — adding a comment update"
+    gh issue comment --repo "$REPO" --body "Updated roadmap: $meta_issue_body" --issue-number "$existing_meta"
+  else
+    echo "No existing meta issue found: creating one"
+    meta_id=$(gh issue create --repo "$REPO" --title "Roadmap: next steps and critical tasks" --body "$meta_issue_body" --label "type:task,status:open" --json number --jq '.number')
+    echo "Meta issue created: https://github.com/$REPO/issues/$meta_id"
+  fi
+else
+  echo "Dry run: No issues created. Rerun with APPLY=true to actually create."
+  echo "Planned issue list:\n$meta_issue_body"
+fi

--- a/scripts/gh/create-labels.ps1
+++ b/scripts/gh/create-labels.ps1
@@ -1,0 +1,33 @@
+param(
+  [string]$Repo = 'tzervas/lan-runner'
+)
+
+function New-LabelIfMissing {
+  param(
+    [string]$Name,
+    [string]$Color = 'ededed',
+    [string]$Desc = ''
+  )
+  $labels = gh label list --repo $Repo --limit 200 --json name --jq '.[] | .name' 2>$null | Out-String
+  if ($labels -match "^$Name$" -or $labels -match "\n$Name\n") {
+    Write-Host "label '$Name' exists"
+  } else {
+    Write-Host "creating label '$Name'"
+    gh label create $Name --color $Color --description $Desc --repo $Repo
+  }
+}
+
+New-LabelIfMissing -Name 'type:task' -Color 'f9d0c4' -Desc 'Task'
+New-LabelIfMissing -Name 'type:enhancement' -Color '0e8a16' -Desc 'Enhancement'
+New-LabelIfMissing -Name 'area:ci' -Color '1d76db' -Desc 'CI and automation'
+New-LabelIfMissing -Name 'area:infra' -Color 'bfe5bf' -Desc 'Infrastructure tasks'
+New-LabelIfMissing -Name 'area:monitoring' -Color 'c2e0ff' -Desc 'Monitoring & observability'
+New-LabelIfMissing -Name 'area:ollama' -Color 'fef2c0' -Desc 'Ollama specifics'
+New-LabelIfMissing -Name 'area:k8s' -Color 'd4c5f9' -Desc 'Kubernetes/ARC'
+New-LabelIfMissing -Name 'area:docs' -Color 'ffdfba' -Desc 'Documentation'
+New-LabelIfMissing -Name 'priority:high' -Color 'b60205' -Desc 'High priority'
+New-LabelIfMissing -Name 'priority:medium' -Color 'fbca04' -Desc 'Medium priority'
+New-LabelIfMissing -Name 'priority:low' -Color '0e8a16' -Desc 'Low priority'
+New-LabelIfMissing -Name 'status:open' -Color '8bb3ff' -Desc 'Open'
+
+Write-Host "Done creating labels for $Repo"

--- a/scripts/gh/create-labels.sh
+++ b/scripts/gh/create-labels.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Creates a set of repository labels for task tracking. Uses 'gh' CLI.
+REPO=${1:-tzervas/lan-runner}
+
+label_create() {
+  name="$1"
+  color=${2:-"ededed"}
+  description=${3:-""}
+  if gh label list --repo "$REPO" | grep -q "^$name\b"; then
+    echo "label '$name' exists"
+  else
+    echo "creating label '$name'"
+    gh label create "$name" --color "$color" --description "$description" --repo "$REPO"
+  fi
+}
+
+label_create "type:task" "f9d0c4" "Task"
+label_create "type:enhancement" "0e8a16" "Enhancement" 
+label_create "area:ci" "1d76db" "CI and automation"
+label_create "area:infra" "bfe5bf" "Infrastructure tasks"
+label_create "area:monitoring" "c2e0ff" "Monitoring & observability"
+label_create "area:ollama" "fef2c0" "Ollama specifics"
+label_create "area:k8s" "d4c5f9" "Kubernetes/ARC"
+label_create "area:docs" "ffdfba" "Documentation"
+label_create "priority:high" "b60205" "High priority"
+label_create "priority:medium" "fbca04" "Medium priority"
+label_create "priority:low" "0e8a16" "Low priority"
+label_create "status:open" "8bb3ff" "Open"
+
+echo "Done creating labels for $REPO"

--- a/scripts/gh/enrich-issues.ps1
+++ b/scripts/gh/enrich-issues.ps1
@@ -1,0 +1,106 @@
+param(
+  [string]$Repo = 'tzervas/lan-runner',
+  [switch]$Apply
+)
+
+function Get-Body($num) {
+  $current = gh issue view --repo $Repo $num --json body --jq '.body' 2>$null
+  return $current
+}
+
+function Update-Body($num, $newBody) {
+  gh issue edit --repo $Repo $num --body "$newBody"
+}
+
+$items = @(
+  @{ num = 2;  title = 'Add CI integration test workflow'; body = @(
+        '## Acceptance criteria',
+        '- [ ] CI runs `docker compose up` (ollama-only) and `test.sh` successfully (timeout and retries)',
+        '- [ ] Workflow brings up services on PR push and cleans up after tests',
+        '- [ ] No secrets are recorded in logs and the workflow is idempotent',
+        '- [ ] Document how to run locally and required secrets (if any)'
+      ) -join "`n"
+  }
+  @{ num = 3; title = 'Add image security scanning'; body = @(
+        '## Acceptance criteria',
+        '- [ ] Add Trivy (or equivalent) step into CI to scan for vulnerabilities',
+        '- [ ] Block PRs on critical vulnerabilities (policy)',
+        '- [ ] Document how to run locally and how to customize policy levels'
+      ) -join "`n"
+  }
+  @{ num = 4; title = 'Add integration tests for runner registration'; body = @(
+        '## Acceptance criteria',
+        '- [ ] Create e2e test verifying ephemeral runner registration to a repo/org (rotating tokens)',
+        '- [ ] Automated cleanup to remove test runners',
+        '- [ ] Document the manual steps / ephemeral token requirements'
+      ) -join "`n"
+  }
+  @{ num = 5; title = 'Add Ollama model preloading'; body = @(
+        '## Acceptance criteria',
+        '- [ ] Provide a script to `ollama pull` configured models',
+        '- [ ] Integrate preload into compose and k8s init containers or documented steps',
+        '- [ ] Add tests to verify models are present post startup'
+      ) -join "`n"
+  }
+  @{ num = 6; title = 'Add monitoring and logging stack'; body = @(
+        '## Acceptance criteria',
+        '- [ ] Add Prometheus scrape configs or exporters for Ollama and Runner',
+        '- [ ] Add a Grafana dashboard skeleton and example alerts',
+        '- [ ] Document recommended retention & disk sizing for logs'
+      ) -join "`n"
+  }
+  @{ num = 7; title = 'Create Helm chart'; body = @(
+        '## Acceptance criteria',
+        '- [ ] Create a Helm chart scaffold and values.yaml for infra/lan-runner',
+        '- [ ] Document chart usage and overlays (lite, gpu, nodeport)',
+        '- [ ] Provide a simple template for model preloading'
+      ) -join "`n"
+  }
+  @{ num = 8; title = 'ARM64 multi-arch support'; body = @(
+        '## Acceptance criteria',
+        '- [ ] Document ARM64 limitations and supported images',
+        '- [ ] Add multi-arch build or verify existing images on ARM using qemu',
+        '- [ ] Add CI test matrix (optional)'
+      ) -join "`n"
+  }
+  @{ num = 9; title = 'Ansible playbook for host setup'; body = @(
+        '## Acceptance criteria',
+        '- [ ] Provide a role to install Docker, Compose and optionally NVIDIA toolkit',
+        '- [ ] Role is idempotent and documented for initial host setup',
+        '- [ ] Example playbooks for both CPU-only host and GPU host'
+      ) -join "`n"
+  }
+  @{ num = 10; title = 'Add CONTRIBUTING.md and GPG guidance'; body = @(
+        '## Acceptance criteria',
+        '- [ ] Add a CONTRIBUTING.md with GPG `git` sign instructions',
+        '- [ ] Add PR template and developer guidelines for agent-assisted PRs',
+        '- [ ] Add a review checklist for large infra changes'
+      ) -join "`n"
+  }
+  @{ num = 12; title = 'Add auto-scaling for runners'; body = @(
+        '## Acceptance criteria',
+        '- [ ] Add sample autoscaling recipe to k8s overlay (ARC HPA or custom hook to scale runners)',
+        '- [ ] Add tests to verify runner count increases with increased job load',
+        '- [ ] Document how to scale down and salvage unused resources'
+      ) -join "`n"
+  }
+)
+
+foreach ($item in $items) {
+  $num = $item.num
+  $title = $item.title
+  $ext = $item.body
+  Write-Host ("Enriching issue #{0}: {1}" -f $num, $title)
+  $cur = Get-Body $num
+  if ($cur -match '<!-- enriched -->') {
+    Write-Host "Issue #$num already enriched - skipping"
+    continue
+  }
+  $new = "$cur`n`n$ext`n`n<!-- enriched -->"
+  if ($Apply) {
+    Update-Body $num $new
+    Write-Host ("Updated issue #{0}" -f $num)
+  } else {
+    Write-Host ("Dry-run: Would update issue #{0} with acceptance criteria" -f $num)
+  }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,86 @@
+version = 1
+revision = 2
+requires-python = ">=3.12"
+
+[[package]]
+name = "lan-runner"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "yamllint" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "yamllint" }]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "yamllint"
+version = "1.37.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathspec" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/f2/cd8b7584a48ee83f0bc94f8a32fea38734cefcdc6f7324c4d3bfc699457b/yamllint-1.37.1.tar.gz", hash = "sha256:81f7c0c5559becc8049470d86046b36e96113637bcbe4753ecef06977c00245d", size = 141613, upload-time = "2025-05-04T08:25:54.355Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/b9/be7a4cfdf47e03785f657f94daea8123e838d817be76c684298305bd789f/yamllint-1.37.1-py3-none-any.whl", hash = "sha256:364f0d79e81409f591e323725e6a9f4504c8699ddf2d7263d8d2b539cd66a583", size = 68813, upload-time = "2025-05-04T08:25:52.552Z" },
+]


### PR DESCRIPTION
This PR adds CI workflows for integration testing, linting, and automation, along with supporting scripts for CI and GitHub operations.

## Summary by Sourcery

Add automated integration, linting, and roadmap-management workflows along with supporting CI and GitHub automation scripts.

Enhancements:
- Introduce reusable scripts to register and validate ephemeral GitHub Actions runners via Docker Compose.
- Add scripts to generate registration tokens and manage GitHub labels and roadmap issues using the gh CLI.

CI:
- Add integration test workflow that brings up the Docker Compose stack (Ollama-only) and runs smoke tests on pushes and pull requests.
- Add DIND-based and self-hosted workflows to perform end-to-end runner registration tests using temporary runners and cleanup.
- Add lint workflow using github/super-linter for pushes and pull requests.
- Add workflow to automate creation of labels and roadmap issues using repository automation scripts.

Documentation:
- Document GitHub automation helper scripts and runner registration workflows in scripts/gh/README.md.

Tests:
- Add CI-backed smoke test of the Docker Compose stack to validate Ollama service health and test script execution.